### PR TITLE
fix: accurately track allocatable resources for nodes

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -82,9 +82,8 @@ type InstanceType struct {
 	// of Kubernetes.
 	Overhead *InstanceTypeOverhead
 
-	onReadOnce   sync.Once
-	onUpdateOnce sync.Once
-	allocatable  v1.ResourceList
+	once        sync.Once
+	allocatable v1.ResourceList
 }
 
 type InstanceTypes []*InstanceType
@@ -96,14 +95,12 @@ func (i *InstanceType) precompute() {
 }
 
 func (i *InstanceType) Allocatable() v1.ResourceList {
-	i.onReadOnce.Do(i.precompute)
+	i.once.Do(i.precompute)
 	return i.allocatable.DeepCopy()
 }
 
-// Should be called only when there's a change, as it can be expensive
 func (i *InstanceType) UpdateAllocatable(newAllocatable v1.ResourceList) {
 	i.allocatable = newAllocatable
-	i.onUpdateOnce.Do(i.precompute)
 }
 
 func (its InstanceTypes) OrderByPrice(reqs scheduling.Requirements) InstanceTypes {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -82,8 +82,9 @@ type InstanceType struct {
 	// of Kubernetes.
 	Overhead *InstanceTypeOverhead
 
-	once        sync.Once
-	allocatable v1.ResourceList
+	onReadOnce   sync.Once
+	onUpdateOnce sync.Once
+	allocatable  v1.ResourceList
 }
 
 type InstanceTypes []*InstanceType
@@ -95,8 +96,14 @@ func (i *InstanceType) precompute() {
 }
 
 func (i *InstanceType) Allocatable() v1.ResourceList {
-	i.once.Do(i.precompute)
+	i.onReadOnce.Do(i.precompute)
 	return i.allocatable.DeepCopy()
+}
+
+// Should be called only when there's a change, as it can be expensive
+func (i *InstanceType) UpdateAllocatable(newAllocatable v1.ResourceList) {
+	i.allocatable = newAllocatable
+	i.onUpdateOnce.Do(i.precompute)
 }
 
 func (its InstanceTypes) OrderByPrice(reqs scheduling.Requirements) InstanceTypes {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -99,7 +99,7 @@ func (i *InstanceType) Allocatable() v1.ResourceList {
 	return i.allocatable.DeepCopy()
 }
 
-func (i *InstanceType) UpdateAllocatable(newAllocatable v1.ResourceList) {
+func (i *InstanceType) SetAllocatable(newAllocatable v1.ResourceList) {
 	i.allocatable = newAllocatable
 }
 

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -89,7 +89,7 @@ func (r *Registration) syncNode(ctx context.Context, nodeClaim *v1beta1.NodeClai
 		nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 		nodeClaim.Labels[v1.LabelInstanceTypeStable],
 	)
-	sharedcache.SharedCache().Add(cacheMapKey, stored.Status.Allocatable, 0)
+	sharedcache.SharedCache().Set(cacheMapKey, stored.Status.Allocatable, sharedcache.DefaultSharedCacheTTL)
 	nodeClaim.Status.Allocatable = stored.Status.Allocatable
 
 	node = nodeclaimutil.UpdateNodeOwnerReferences(nodeClaim, node)

--- a/pkg/controllers/nodepool/hash/controller.go
+++ b/pkg/controllers/nodepool/hash/controller.go
@@ -67,7 +67,7 @@ func (c *Controller) Reconcile(ctx context.Context, np *v1beta1.NodePool) (recon
 	if !equality.Semantic.DeepEqual(stored, np) {
 		// Clear relevant allocatable cache if the hash has changed
 		for cacheKey := range sharedcache.SharedCache().Items() {
-			if strings.HasPrefix(cacheKey, fmt.Sprintf("allocatableCache;%s", np.Name)) {
+			if strings.HasPrefix(cacheKey, fmt.Sprintf("allocatableCache;%s;", np.Name)) {
 				sharedcache.SharedCache().Delete(cacheKey)
 			}
 		}

--- a/pkg/controllers/nodepool/hash/controller.go
+++ b/pkg/controllers/nodepool/hash/controller.go
@@ -65,14 +65,14 @@ func (c *Controller) Reconcile(ctx context.Context, np *v1beta1.NodePool) (recon
 	})
 
 	if !equality.Semantic.DeepEqual(stored, np) {
-		if err := c.kubeClient.Patch(ctx, np, client.MergeFrom(stored)); err != nil {
-			return reconcile.Result{}, client.IgnoreNotFound(err)
-		}
 		// Clear relevant allocatable cache if the hash has changed
 		for cacheKey := range sharedcache.SharedCache().Items() {
 			if strings.HasPrefix(cacheKey, fmt.Sprintf("allocatableCache;%s", np.Name)) {
 				sharedcache.SharedCache().Delete(cacheKey)
 			}
+		}
+		if err := c.kubeClient.Patch(ctx, np, client.MergeFrom(stored)); err != nil {
+			return reconcile.Result{}, client.IgnoreNotFound(err)
 		}
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -265,7 +265,7 @@ func (n *NodeClaim) filterInstanceTypesByRequirements(requirements scheduling.Re
 		)
 		cachedAllocatable, ok := sharedcache.SharedCache().Get(cacheMapKey)
 		if ok && cachedAllocatable != nil {
-			it.UpdateAllocatable(cachedAllocatable.(v1.ResourceList))
+			it.SetAllocatable(cachedAllocatable.(v1.ResourceList))
 		}
 
 		itFits := fits(it, requests)

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/utils/resources"
+	"sigs.k8s.io/karpenter/pkg/utils/sharedcache"
 )
 
 // NodeClaim is a set of constraints, compatible pods, and possible instance types that could fulfill these constraints. This
@@ -101,7 +102,7 @@ func (n *NodeClaim) Add(pod *v1.Pod) error {
 	// Check instance type combinations
 	requests := resources.Merge(n.Spec.Resources.Requests, resources.RequestsForPods(pod))
 
-	filtered := filterInstanceTypesByRequirements(n.InstanceTypeOptions, nodeClaimRequirements, requests)
+	filtered := n.filterInstanceTypesByRequirements(nodeClaimRequirements, requests)
 
 	if len(filtered.remaining) == 0 {
 		// log the total resources being requested (daemonset + the pod)
@@ -239,7 +240,7 @@ func (r filterResults) FailureReason() string {
 }
 
 //nolint:gocyclo
-func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceType, requirements scheduling.Requirements, requests v1.ResourceList) filterResults {
+func (n *NodeClaim) filterInstanceTypesByRequirements(requirements scheduling.Requirements, requests v1.ResourceList) filterResults {
 	results := filterResults{
 		requests:        requests,
 		requirementsMet: false,
@@ -251,10 +252,22 @@ func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceTy
 		fitsAndOffering:         false,
 	}
 
-	for _, it := range instanceTypes {
+	for _, it := range n.InstanceTypeOptions {
 		// the tradeoff to not short circuiting on the filtering is that we can report much better error messages
 		// about why scheduling failed
 		itCompat := compatible(it, requirements)
+
+		// update instance type allocatables from cache if available
+		cacheMapKey := fmt.Sprintf(
+			"allocatableCache;%s;%s",
+			n.NodePoolName,
+			it.Name,
+		)
+		cachedAllocatable, ok := sharedcache.SharedCache().Get(cacheMapKey)
+		if ok && cachedAllocatable != nil {
+			it.UpdateAllocatable(cachedAllocatable.(v1.ResourceList))
+		}
+
 		itFits := fits(it, requests)
 		itHasOffering := it.Offerings.Available().HasCompatible(requirements)
 

--- a/pkg/utils/sharedcache/sharedcache.go
+++ b/pkg/utils/sharedcache/sharedcache.go
@@ -1,0 +1,19 @@
+package sharedcache
+
+import (
+	"sync"
+
+	"github.com/patrickmn/go-cache"
+)
+
+// private variable to hold the instance
+var sharedCache *cache.Cache
+var once sync.Once
+
+// SharedCache provides a global point of access to the Cache instance
+func SharedCache() *cache.Cache {
+	once.Do(func() {
+		sharedCache = cache.New(cache.NoExpiration, cache.NoExpiration)
+	})
+	return sharedCache
+}

--- a/pkg/utils/sharedcache/sharedcache.go
+++ b/pkg/utils/sharedcache/sharedcache.go
@@ -2,18 +2,20 @@ package sharedcache
 
 import (
 	"sync"
+	"time"
 
 	"github.com/patrickmn/go-cache"
 )
 
-// private variable to hold the instance
 var sharedCache *cache.Cache
 var once sync.Once
+
+const DefaultSharedCacheTTL time.Duration = time.Hour * 24
 
 // SharedCache provides a global point of access to the Cache instance
 func SharedCache() *cache.Cache {
 	once.Do(func() {
-		sharedCache = cache.New(cache.NoExpiration, cache.NoExpiration)
+		sharedCache = cache.New(DefaultSharedCacheTTL, time.Hour)
 	})
 	return sharedCache
 }

--- a/pkg/utils/sharedcache/sharedcache.go
+++ b/pkg/utils/sharedcache/sharedcache.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sharedcache
 
 import (


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require a PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter-provider-aws/issues/5161

**Description**
The current method of assuming allocatable memory by simply discarding a percentage of usable memory using the `VM_MEMORY_OVERHEAD_PERCENT` global variable is suboptimal. There is no value that would avoid both over- and underestimating of memory allocatable.

Cluster-autoscaler addresses this issue by learning about the true allocatable memory from actual nodes and retaining that information. In this pull request, I'm applying the same concept.
In this pull request, I'm applying the same concept.


To demonstrate the issue:
1. Set `VM_MEMORY_OVERHEAD_PERCENT` to 0
2. Create a nodepool with a single instance type:
```yaml
apiVersion: karpenter.sh/v1beta1
kind: NodePool
metadata:
  name: approaching-allocatable-nodepool-0
spec:
  limits:
    cpu: "18"
    memory: 36Gi
  template:
    metadata:
      labels:
        approaching-allocatable: nodepool-0
    spec:
      nodeClassRef:
        apiVersion: karpenter.k8s.aws/v1beta1
        kind: EC2NodeClass
        name: approaching-allocatable-nodeclass-0
      requirements:
      - key: node.kubernetes.io/instance-type
        operator: In
        values:
        - t4g.medium
      taints:
      - effect: NoExecute
        key:  approaching-allocatable
        value: "nodepool-0"
      kubelet:
        systemReserved:
          memory: "1Ki"
        kubeReserved:
          memory: "1Ki"
        evictionHard:
          memory.available: "1Ki"

```
3. Create a workload with request close to node's allocatable:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: approaching-allocatable-pod
  namespace: default
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: approaching-allocatable
            operator: In
            values:
            - nodepool-0
  containers:
  - image: public.ecr.aws/eks-distro/kubernetes/pause@sha256:c2518f6d82392ba799d551398805aaa7af70548015263d962afe9710c0eaa1b2
    name: trigger-pod
    resources:
      requests:
        cpu: 10m
        memory: 3686Mi
  tolerations:
  - effect: NoExecute
    key: approaching-allocatable
    operator: Equal
    value: nodepool-0
```


#### Observed behaviors
1. **Resolving Resource Overestimation:**
   - **v0.37.0 behavior:** Karpenter continuously creates and consolidates nodes without realizing the impossibility of fitting the workload.
   - **Patched behavior:** Accurately tracks actual allocatable resources, preventing the endless loop of node creation and consolidation.

2. **Addressing Resource Underestimation:**
   - **v0.37.0 behavior:** Karpenter leaves pods pending indefinitely or chooses an instance type larger than necessary, failing to learn from actual node allocatables when launched for other reasons.
   - **Patched behavior:** Remembers true allocatable resources if a node is ever launched, enabling correct node launches for previously pending pods.

3. **Avoiding Extra Churn:**
   - **v0.37.0 behavior:** Incorrect predicted allocatable resources during consolidation lead to unnecessary churn.
   - **Patched behavior:** Scheduling simulations benefit from knowledge about true allocatable resources

The above improvements are implemented using a shared cache that can be accessed from:
- **lifecycle package:** to populate the cache as soon as a node is registered.
- **scheduling package:** to use real allocatable resources when making `itFits` decisions from the cache, if available.
- **hash package:** to flush the cache for a nodepool after an update.

I tried to avoid introducing a global-like package, but placing the cache in any of the above packages (or others) introduces more coupling between those packages. If there is a definitive place for such a cache, please let me know.

**How was this change tested?**
For overestimation:
I ran this in one of our preprod EKS cluster with `vmMemoryOverheadPercent=0`, and it correctly stops re-launching the nodes of a given nodepool-instancetype combination after the first attempt fails. It also uses the correct allocatable memory for scheduling.

For underestimation:
The test was to
 1. set high `VM_MEMORY_OVERHEAD_PERCENT` value (like 0.2)
 2. Run the workload that was fitting before, observe it's pending
 3. Adding another workload for same nodepool, but with lower request. That launches the real node
 4. Another node would launch for the pod from step 2, and new pods with same requests are now correctly cause new node to be launched

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
